### PR TITLE
[Shorten URL] Use http://is.gb with no https mode

### DIFF
--- a/zerobin/static/js/behavior.js
+++ b/zerobin/static/js/behavior.js
@@ -178,9 +178,19 @@ window.zerobin = {
   /** Get a tinyurl using JSONP */
   getTinyURL: function(longURL, success) {
     var api = 'http://is.gd/create.php?format=json&url=';
-    $.getJSON(api + encodeURIComponent(longURL) + '&callback=?', function(data){
-      success(data.shorturl);
-    });
+      $.ajax({
+		  url: 'https://www.googleapis.com/urlshortener/v1/url',
+		  type: 'POST',
+          contentType: 'application/json',
+          data: JSON.stringify({
+              "longUrl": longURL
+		  }),
+		  processData: false,
+		  dataType: 'json'
+	  }).done(function(data){
+		  console.log(data);
+		  success(data.id);
+      });
   },
 
   /** Check for browser support of the named featured. Store the result


### PR DESCRIPTION
Hello, we are using 0bin over https and when you click on shorten url, all the benefit of the SSL and encrypted 0bin is dead since 
1. is.gb knows the password - but let's say it's ok
2. is.gb has no over ssl mode - too bad

This feature should be over ssl since you send the encryption key.
