### PR TITLE
Misspelling check.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,7 +57,7 @@ Other features
 - copy paste to clipboard in a click;
 - get paste short URL in a click;
 - own previous pastes history;
-- visual hash of a paste to easily tell it appart from others in a list.
+- visual hash of a paste to easily tell it apart from others in a list.
 
 Technologies used
 ==================

--- a/docs/en/apache_install.rst
+++ b/docs/en/apache_install.rst
@@ -16,7 +16,7 @@ An Apache setup is still much more robust and secure than an easy installation.
 Une installation apache est aussi beaucoup plus solide et sécurisé qu'une
 installation facile. You'll benefit from having:
 
-- the possiblity to have several projects listening to the port 80;
+- the possibility to have several projects listening to the port 80;
 - several Apache module at your disposal (like requests throttling);
 - Apache robustness in front end: it's secure, and there is much less chance
   it will crash under heavy load;

--- a/docs/en/intro.rst
+++ b/docs/en/intro.rst
@@ -45,7 +45,7 @@ Other features
 - copy paste to clipboard in a click;
 - get paste short URL in a click;
 - own previous pastes history;
-- visual hash of a paste to easily tell it appart from others in a list.
+- visual hash of a paste to easily tell it apart from others in a list.
 
 Technologies used
 ==================

--- a/docs/en/nginx_install.rst
+++ b/docs/en/nginx_install.rst
@@ -24,7 +24,7 @@ Therefor there are two steps:
 
 You will benefit from having:
 
-- the possiblity to have several projects listening to the port 80;
+- the possibility to have several projects listening to the port 80;
 - several Apache module at your disposal (like requests throttling);
 - Apache robustness in front end: it's secure, and there is much less chance
   it will crash under heavy load;
@@ -40,7 +40,7 @@ Run 0bin as usual, but this time make it listen to a local port and host. E.G::
 
     zerobin --host 127.0.0.1 --port 8000
 
-In PHP, when you edit a file, the changes are immediatly visible. In Python,
+In PHP, when you edit a file, the changes are immediately visible. In Python,
 the whole code is often loaded in memory for performance reasons. This means
 you have to restart the Python process to see the changes effect. Having a
 separate process let you do this without having to restart the server.

--- a/docs/en/options.rst
+++ b/docs/en/options.rst
@@ -159,7 +159,7 @@ List of absolute path to directories containing templates that 0bin uses to
 generate the web site pages. The first list items have priotity on the later.
 
 If you wish to use your own templates, add the directory containing them
-at the begining of the list::
+at the beginning of the list::
 
   from zerobin.defauls_settings import TEMPLATE_DIRS
 

--- a/docs/example_settings.py
+++ b/docs/example_settings.py
@@ -50,7 +50,7 @@ MENU = (
     ('Contact', 'mailto:your@email.com') # email
 )
 
-# limit size of pasted text in bytes. Be carefull allowing too much size can slow down user's
+# limit size of pasted text in bytes. Be careful allowing too much size can slow down user's
 # browser
 MAX_SIZE = 1024 * 500
 MAX_SIZE_KB = int(math.ceil(MAX_SIZE / 1024.0))

--- a/docs/fr/apache_install.rst
+++ b/docs/fr/apache_install.rst
@@ -33,8 +33,8 @@ Les serveurs Web Python modernes fonctionnent tous de la même manière, en suiv
 une norme d'interfaçage: WSGI.
 
 C'est la solution la plus performante, et celle recommandée. Mais elle demande
-l'installation du modle Apache mod_wsgi. Si vous ne savez pas comment faire,
-ou si vous ne pouvez pas le faire (par exemple sur un hébergement mutualisé
+l'installation du model Apache mod_wsgi. Si vous ne savez pas comment faire,
+ou si vous ne pouvez pas le faire (par example sur un hébergement mutualisé
 qui ne le propose pas), il vous faudra choisir l'installation CGI.
 
 Premièrement, assurez-vous d'avoir mod_wsgi installé et chargé (en tant qu'admin)::

--- a/docs/fr/easy_install.rst
+++ b/docs/fr/easy_install.rst
@@ -40,7 +40,7 @@ solutions.
 
 *Pour un petit site:*
 
-Lancer simplement 0bin en processus shell d'arrière plan. Exemple sous GNU/Linux::
+Lancer simplement 0bin en processus shell d'arrière plan. Example sous GNU/Linux::
 
   nohup python zerobin.py --host 0.0.0.0 --port 80 --compressed-static &
 

--- a/libs/bottle.py
+++ b/libs/bottle.py
@@ -1457,7 +1457,7 @@ class JSONPlugin(object):
             if isinstance(rv, dict):
                 #Attempt to serialize, raises exception on failure
                 json_response = dumps(rv)
-                #Set content type only if serialization succesful
+                #Set content type only if serialization successful
                 response.content_type = 'application/json'
                 return json_response
             return rv

--- a/libs/cherrypy/_cpcompat.py
+++ b/libs/cherrypy/_cpcompat.py
@@ -96,7 +96,7 @@ try:
     from base64 import decodebytes as _base64_decodebytes
 except ImportError:
     # Python 3.0-
-    # since CherryPy claims compability with Python 2.3, we must use
+    # since CherryPy claims compatibility with Python 2.3, we must use
     # the legacy API of base64
     from base64 import decodestring as _base64_decodebytes
 

--- a/libs/cherrypy/lib/sessions.py
+++ b/libs/cherrypy/lib/sessions.py
@@ -598,7 +598,7 @@ class MemcachedSession(Session):
     # Wrap all .get and .set operations in a single lock.
     mc_lock = threading.RLock()
     
-    # This is a seperate set of locks per session id.
+    # This is a separate set of locks per session id.
     locks = {}
     
     servers = ['127.0.0.1:11211']

--- a/libs/cherrypy/process/plugins.py
+++ b/libs/cherrypy/process/plugins.py
@@ -312,7 +312,7 @@ class Daemonizer(SimplePlugin):
     process still return proper exit codes. Therefore, if you use this
     plugin to daemonize, don't use the return code as an accurate indicator
     of whether the process fully started. In fact, that return code only
-    indicates if the process succesfully finished the first fork.
+    indicates if the process successfully finished the first fork.
     """
     
     def __init__(self, bus, stdin='/dev/null', stdout='/dev/null',

--- a/libs/privilege.py
+++ b/libs/privilege.py
@@ -141,7 +141,7 @@ def get_sups():
 def set_sups(target_sups):
     """
     This is designed to give us a layer of abstraction from the system calls.
-    It also accomodates FreeBSD's idiosyncracy (which is POSIX-compliant) of
+    It also accommodates FreeBSD's idiosyncrasy (which is POSIX-compliant) of
     keeping the egid in the supplementary groups list.
     It also makes an effort to not call the setgroups routine if the target
     group list is identical to the current one in force.

--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,7 @@ setup(
 
 
     ##########################################################################
-    # Parameters you definitly should fill even if they are optional         #
+    # Parameters you definitely should fill even if they are optional         #
     # You need to either fill or comment them, or setup.py install will fail #
     ##########################################################################
 
@@ -183,7 +183,7 @@ setup(
 
     ## Iterable of strings being names of modules you wish to include as well
     ## It's more accurate than a package
-    ## espcially usefull if you have lonelly modules at the root level
+    ## espcially useful if you have lonelly modules at the root level
     # E.G: ['mod1', 'pkg.mod2'] if you have mod1.py and pkg/mod2.py
     # py_modules= ,
 
@@ -226,7 +226,7 @@ setup(
 
     # Iterable of string being metadata. You can't add yours and pypi is picky
     # about the syntax, so just uncomment the one you want to set.
-    # It is adviced to at least provide "Operating System" and "Licence"
+    # It is advised to at least provide "Operating System" and "Licence"
     # Incompatibel with 2.2.3- or 2.3-
     classifiers=[
         'Programming Language :: Python',
@@ -981,7 +981,7 @@ setup(
 
 
     ## A mapping of strings / iterable, the key being the name of a extra
-    ## feature, and the iterable containing dependancy names.
+    ## feature, and the iterable containing dependency names.
     ## Sometimes a project has "recommended" dependencies, that are not required
     ## for all uses of the project. For example, a project might offer optional PDF
     ## output if ReportLab is installed, and reStructuredText support if docutils

--- a/zerobin/default_settings.py
+++ b/zerobin/default_settings.py
@@ -67,6 +67,6 @@ MENU = (
     ('Contact', 'mailto:your@email.com') # email
 )
 
-# limit size of pasted text in bytes. Be carefull allowing too much size can
+# limit size of pasted text in bytes. Be careful allowing too much size can
 # slow down user's browser
 MAX_SIZE = 1024 * 500

--- a/zerobin/routes.py
+++ b/zerobin/routes.py
@@ -3,7 +3,7 @@
 # vim: ai ts=4 sts=4 et sw=4
 
 """
-    Main script including controller, rooting, dependancy management, and
+    Main script including controller, rooting, dependency management, and
     server run.
 """
 

--- a/zerobin/static/js/lzw.js
+++ b/zerobin/static/js/lzw.js
@@ -1,6 +1,6 @@
 // Author: Anthony McKale
 //
-// Note: modifed to javascript from orginal as2 found below
+// Note: modifed to javascript from original as2 found below
 // basically identical actual to as2
 //
 // http://www.razorberry.com/blog/archives/2004/08/22/lzw-compression-methods-in-as2/


### PR DESCRIPTION
Fixed the spelling using the following command:

  misspellings -s fix.sh $(find \* -type f)
  sh fix.sh

Nothing very important, just was using it for a quick test.
