### PR TITLE
Use execfile() instead of import machinery for --settings-file

### DIFF
--- a/zerobin/utils.py
+++ b/zerobin/utils.py
@@ -14,6 +14,15 @@ try:
 except (AttributeError):
     pass # privilege does't work on several plateform
 
+try:
+    from runpy import run_path
+except ImportError:
+    # python-2.6 or earlier - use simplier less-optimized execfile()
+    def run_path(file_path):
+        mod_globals = {'__file__': file_path}
+        execfile(file_path, mod_globals)
+        return mod_globals
+
 
 def drop_privileges(user=None, group=None, wait=5):
     """
@@ -69,15 +78,23 @@ class SettingsContainer(object):
         return cls._instance
 
 
-    def update_with_module(self, module):
+    def update_with_dict(self, dict):
         """
-            Update settings with values from the given module.
+            Update settings with values from the given mapping object.
             (Taking only variable with uppercased name)
         """
-        for name, value in module.__dict__.iteritems():
+        for name, value in dict.iteritems():
             if name.isupper():
                 setattr(self, name, value)
         return self
+
+
+    def update_with_module(self, module):
+        """
+            Update settings with values from the given module.
+            Uses update_with_dict() behind the scenes.
+        """
+        return self.update_with_dict(module.__dict__)
 
 
     @classmethod
@@ -94,11 +111,10 @@ class SettingsContainer(object):
     def update_with_file(self, filepath):
         """
             Update settings with values from the given module file.
-            User update_with_module() behind the scene
+            Uses update_with_dict() behind the scenes.
         """
-        sys.path.insert(0, os.path.dirname(filepath))
-        module_name = os.path.splitext(os.path.basename(filepath))[0]
-        return self.update_with_module(__import__(module_name))
+        settings = run_path(filepath)
+        return self.update_with_dict(settings)
 
 
 settings = SettingsContainer()


### PR DESCRIPTION
Problem with import is that it:
- Reuses already-imported module.
  
  For example, --settings-file=/etc/zerobin.py won't be imported,
  because sys.modules will already contain 'zerobin' entry.
- Alters sys.path.
  
  Importing module from a heavily-populated directory may potentially
  cause next imports to run code from totally unexpected places.

Using execfile() does not seem to have any of these downsides.
